### PR TITLE
Change font and remove legacy bootloader option

### DIFF
--- a/src/flash-multi/Dialogs/DfuRecoveryDialog.Designer.cs
+++ b/src/flash-multi/Dialogs/DfuRecoveryDialog.Designer.cs
@@ -96,8 +96,8 @@ namespace Flash_Multi
             // 
             // DfuRecoveryDialog
             // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ControlBox = false;
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.panel2);

--- a/src/flash-multi/Dialogs/DfuRecoveryDialog.resx
+++ b/src/flash-multi/Dialogs/DfuRecoveryDialog.resx
@@ -118,11 +118,14 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="dialogText.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
   <data name="dialogText.Location" type="System.Drawing.Point, System.Drawing">
     <value>54, 13</value>
   </data>
   <data name="dialogText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>306, 84</value>
+    <value>335, 92</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="dialogText.TabIndex" type="System.Int32, mscorlib">
@@ -146,6 +149,9 @@ Flashing will continue automatically when the module is plugged back in.</value>
   </data>
   <data name="&gt;&gt;dialogText.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="buttonCancel.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
     <value>320, 154</value>
@@ -227,15 +233,6 @@ Flashing will continue automatically when the module is plugged back in.</value>
   <data name="&gt;&gt;warningIcon.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="timerProgressBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>58, 100</value>
-  </data>
-  <data name="timerProgressBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>302, 23</value>
-  </data>
-  <data name="timerProgressBar.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
   <data name="&gt;&gt;timerProgressBar.Name" xml:space="preserve">
     <value>timerProgressBar</value>
   </data>
@@ -269,11 +266,35 @@ Flashing will continue automatically when the module is plugged back in.</value>
   <data name="&gt;&gt;panel2.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="timerProgressBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>58, 112</value>
+  </data>
+  <data name="timerProgressBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>302, 23</value>
+  </data>
+  <data name="timerProgressBar.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;timerProgressBar.Name" xml:space="preserve">
+    <value>timerProgressBar</value>
+  </data>
+  <data name="&gt;&gt;timerProgressBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;timerProgressBar.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;timerProgressBar.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>404, 187</value>
+  </data>
+  <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">

--- a/src/flash-multi/Dialogs/DfuRecoveryDialog.resx
+++ b/src/flash-multi/Dialogs/DfuRecoveryDialog.resx
@@ -272,9 +272,6 @@ Flashing will continue automatically when the module is plugged back in.</value>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>404, 187</value>
   </data>

--- a/src/flash-multi/Dialogs/SerialMonitor.Designer.cs
+++ b/src/flash-multi/Dialogs/SerialMonitor.Designer.cs
@@ -40,8 +40,8 @@
             // 
             // serialOutput
             // 
-            resources.ApplyResources(this.serialOutput, "serialOutput");
             this.serialOutput.BackColor = System.Drawing.SystemColors.ControlLightLight;
+            resources.ApplyResources(this.serialOutput, "serialOutput");
             this.serialOutput.Name = "serialOutput";
             this.serialOutput.ReadOnly = true;
             // 
@@ -90,8 +90,8 @@
             // 
             // SerialMonitor
             // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.checkBoxAutoScroll);
             this.Controls.Add(this.buttonConnect);
             this.Controls.Add(this.buttonDisconnect);

--- a/src/flash-multi/Dialogs/SerialMonitor.resx
+++ b/src/flash-multi/Dialogs/SerialMonitor.resx
@@ -301,13 +301,13 @@
     <value>True</value>
   </data>
   <data name="checkBoxAutoScroll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 335</value>
+    <value>13, 333</value>
   </data>
   <data name="checkBoxAutoScroll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>10, 3, 3, 3</value>
   </data>
   <data name="checkBoxAutoScroll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 17</value>
+    <value>80, 19</value>
   </data>
   <data name="checkBoxAutoScroll.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -332,6 +332,9 @@
   </metadata>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>584, 361</value>
+  </data>
+  <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/src/flash-multi/Dialogs/SerialMonitor.resx
+++ b/src/flash-multi/Dialogs/SerialMonitor.resx
@@ -117,92 +117,221 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="checkBoxAutoScroll.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>584, 361</value>
-  </data>
-  <data name="&gt;&gt;buttonSave.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="buttonClose.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
-  </data>
-  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>520, 250</value>
-  </data>
-  <data name="buttonDisconnect.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="checkBoxAutoScroll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>10, 3, 3, 3</value>
-  </data>
-  <data name="buttonClose.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
-  </data>
-  <data name="&gt;&gt;buttonClose.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="buttonClear.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
-  </data>
-  <data name="buttonSave.Location" type="System.Drawing.Point, System.Drawing">
-    <value>339, 329</value>
-  </data>
-  <data name="buttonConnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
-  </data>
-  <data name="&gt;&gt;serialOutput.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;checkBoxAutoScroll.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="buttonClose.Location" type="System.Drawing.Point, System.Drawing">
-    <value>501, 329</value>
-  </data>
-  <data name="checkBoxAutoScroll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 17</value>
-  </data>
-  <data name="checkBoxAutoScroll.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
   <data name="serialOutput.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="serialOutput.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Lucida Console, 9pt</value>
   </data>
-  <data name="&gt;&gt;serialOutput.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="serialOutput.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
   </data>
-  <data name="&gt;&gt;buttonClose.Name" xml:space="preserve">
-    <value>buttonClose</value>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="serialOutput.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="buttonDisconnect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>258, 329</value>
+  <data name="serialOutput.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Vertical</value>
   </data>
-  <data name="buttonClear.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;checkBoxAutoScroll.Name" xml:space="preserve">
-    <value>checkBoxAutoScroll</value>
-  </data>
-  <data name="&gt;&gt;buttonConnect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonClose.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="serialOutput.Size" type="System.Drawing.Size, System.Drawing">
+    <value>578, 320</value>
   </data>
   <data name="serialOutput.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
+  <data name="&gt;&gt;serialOutput.Name" xml:space="preserve">
+    <value>serialOutput</value>
+  </data>
+  <data name="&gt;&gt;serialOutput.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;serialOutput.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;serialOutput.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="buttonClose.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonClose.Location" type="System.Drawing.Point, System.Drawing">
+    <value>501, 329</value>
+  </data>
+  <data name="buttonClose.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 8, 3</value>
+  </data>
+  <data name="buttonClose.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="buttonClose.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="buttonClose.Text" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="&gt;&gt;buttonClose.Name" xml:space="preserve">
+    <value>buttonClose</value>
+  </data>
+  <data name="&gt;&gt;buttonClose.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonClose.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonClose.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="buttonClear.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonClear.Location" type="System.Drawing.Point, System.Drawing">
+    <value>420, 329</value>
+  </data>
+  <data name="buttonClear.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="buttonClear.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="buttonClear.Text" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="&gt;&gt;buttonClear.Name" xml:space="preserve">
+    <value>buttonClear</value>
+  </data>
+  <data name="&gt;&gt;buttonClear.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonClear.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonClear.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="buttonSave.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonSave.Location" type="System.Drawing.Point, System.Drawing">
+    <value>339, 329</value>
+  </data>
+  <data name="buttonSave.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="buttonSave.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="buttonSave.Text" xml:space="preserve">
+    <value>Save</value>
+  </data>
   <data name="&gt;&gt;buttonSave.Name" xml:space="preserve">
     <value>buttonSave</value>
+  </data>
+  <data name="&gt;&gt;buttonSave.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonSave.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonSave.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="buttonDisconnect.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonDisconnect.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="buttonDisconnect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>258, 329</value>
+  </data>
+  <data name="buttonDisconnect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="buttonDisconnect.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="buttonDisconnect.Text" xml:space="preserve">
+    <value>Disconnect</value>
+  </data>
+  <data name="&gt;&gt;buttonDisconnect.Name" xml:space="preserve">
+    <value>buttonDisconnect</value>
+  </data>
+  <data name="&gt;&gt;buttonDisconnect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonDisconnect.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonDisconnect.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="buttonConnect.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="buttonConnect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>177, 329</value>
+  </data>
+  <data name="buttonConnect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 25</value>
+  </data>
+  <data name="buttonConnect.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="buttonConnect.Text" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="&gt;&gt;buttonConnect.Name" xml:space="preserve">
+    <value>buttonConnect</value>
+  </data>
+  <data name="&gt;&gt;buttonConnect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonConnect.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;buttonConnect.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="checkBoxAutoScroll.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="checkBoxAutoScroll.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="checkBoxAutoScroll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 335</value>
+  </data>
+  <data name="checkBoxAutoScroll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>10, 3, 3, 3</value>
+  </data>
+  <data name="checkBoxAutoScroll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 17</value>
+  </data>
+  <data name="checkBoxAutoScroll.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="checkBoxAutoScroll.Text" xml:space="preserve">
+    <value>Autoscroll</value>
+  </data>
+  <data name="&gt;&gt;checkBoxAutoScroll.Name" xml:space="preserve">
+    <value>checkBoxAutoScroll</value>
+  </data>
+  <data name="&gt;&gt;checkBoxAutoScroll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;checkBoxAutoScroll.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;checkBoxAutoScroll.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>584, 361</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -779,151 +908,19 @@
         bHA4h3O4hcblJ3/pBNA/K2QPHokK5HAO53AXApeL/v8Teuh4O8GGwgAAAABJRU5ErkJggg==
 </value>
   </data>
-  <data name="&gt;&gt;buttonDisconnect.Name" xml:space="preserve">
-    <value>buttonDisconnect</value>
-  </data>
-  <data name="buttonClear.Text" xml:space="preserve">
-    <value>Clear</value>
-  </data>
-  <data name="&gt;&gt;buttonClear.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonDisconnect.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;checkBoxAutoScroll.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;checkBoxAutoScroll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonClear.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="serialOutput.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
-    <value>Vertical</value>
-  </data>
-  <data name="&gt;&gt;buttonDisconnect.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;buttonSave.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="buttonClose.Text" xml:space="preserve">
-    <value>Close</value>
-  </data>
-  <data name="checkBoxAutoScroll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 335</value>
-  </data>
-  <data name="&gt;&gt;buttonConnect.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="checkBoxAutoScroll.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="buttonDisconnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
-  </data>
-  <data name="buttonClear.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
-  </data>
-  <data name="&gt;&gt;buttonSave.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="buttonDisconnect.Text" xml:space="preserve">
-    <value>Disconnect</value>
-  </data>
-  <data name="&gt;&gt;buttonClose.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="buttonSave.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
-  </data>
-  <data name="buttonConnect.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="buttonConnect.Text" xml:space="preserve">
-    <value>Connect</value>
-  </data>
-  <data name="serialOutput.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="serialOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>578, 320</value>
-  </data>
-  <data name="&gt;&gt;buttonConnect.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="buttonSave.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;buttonDisconnect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="buttonConnect.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>SerialMonitor</value>
-  </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Flash Multi Serial Monitor</value>
-  </data>
-  <data name="buttonClose.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="serialOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="serialOutput.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Lucida Console, 9pt</value>
-  </data>
-  <data name="buttonConnect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>177, 329</value>
-  </data>
-  <data name="&gt;&gt;buttonConnect.Name" xml:space="preserve">
-    <value>buttonConnect</value>
-  </data>
-  <data name="&gt;&gt;serialOutput.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="buttonSave.Text" xml:space="preserve">
-    <value>Save</value>
-  </data>
-  <data name="&gt;&gt;serialOutput.Name" xml:space="preserve">
-    <value>serialOutput</value>
-  </data>
-  <data name="checkBoxAutoScroll.Text" xml:space="preserve">
-    <value>Autoscroll</value>
-  </data>
-  <data name="buttonSave.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
-  </data>
-  <data name="buttonClose.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 8, 3</value>
-  </data>
-  <data name="&gt;&gt;buttonClear.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="buttonClear.Location" type="System.Drawing.Point, System.Drawing">
-    <value>420, 329</value>
-  </data>
-  <data name="&gt;&gt;buttonClear.Name" xml:space="preserve">
-    <value>buttonClear</value>
-  </data>
-  <data name="buttonDisconnect.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>520, 250</value>
   </data>
   <data name="$this.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 38</value>
   </data>
-  <data name="buttonDisconnect.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Flash Multi Serial Monitor</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>SerialMonitor</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/src/flash-multi/Dialogs/UsbSupportErrorDialog.Designer.cs
+++ b/src/flash-multi/Dialogs/UsbSupportErrorDialog.Designer.cs
@@ -94,8 +94,7 @@
             // 
             // UsbSupportErrorDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.ClientSize = new System.Drawing.Size(404, 187);
             this.ControlBox = false;
             this.Controls.Add(this.buttonOK);

--- a/src/flash-multi/Dialogs/UsbSupportErrorDialog.Designer.cs
+++ b/src/flash-multi/Dialogs/UsbSupportErrorDialog.Designer.cs
@@ -55,7 +55,7 @@
             this.moreInfoLinkLabel.LinkArea = new System.Windows.Forms.LinkArea(6, 4);
             this.moreInfoLinkLabel.Location = new System.Drawing.Point(57, 114);
             this.moreInfoLinkLabel.Name = "moreInfoLinkLabel";
-            this.moreInfoLinkLabel.Size = new System.Drawing.Size(162, 17);
+            this.moreInfoLinkLabel.Size = new System.Drawing.Size(178, 21);
             this.moreInfoLinkLabel.TabIndex = 3;
             this.moreInfoLinkLabel.TabStop = true;
             this.moreInfoLinkLabel.Text = "Click here for more information.";
@@ -99,6 +99,7 @@
             this.ControlBox = false;
             this.Controls.Add(this.buttonOK);
             this.Controls.Add(this.panel2);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
             this.MinimizeBox = false;

--- a/src/flash-multi/Dialogs/UsbSupportWarningDialog.Designer.cs
+++ b/src/flash-multi/Dialogs/UsbSupportWarningDialog.Designer.cs
@@ -67,9 +67,9 @@
             this.dialogText.Name = "dialogText";
             this.dialogText.Size = new System.Drawing.Size(306, 96);
             this.dialogText.TabIndex = 0;
-            this.dialogText.Text = "The selected firmware file was compiled without USB serial support.  The MULTI-Mo" +
-    "dule bootloader should be updated before writing this firmware.\r\n\r\nClick OK to w" +
-    "rite the firmware.";
+            this.dialogText.Text = "The selected firmware file was compiled without USB serial support. The MULTI-Mod" +
+    "ule bootloader should be updated before writing this firmware.\r\n\r\nClick OK to wr" +
+    "ite the firmware.";
             // 
             // warningIcon
             // 

--- a/src/flash-multi/Dialogs/UsbSupportWarningDialog.Designer.cs
+++ b/src/flash-multi/Dialogs/UsbSupportWarningDialog.Designer.cs
@@ -31,7 +31,6 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UsbSupportWarningDialog));
             this.buttonCancel = new System.Windows.Forms.Button();
             this.panel2 = new System.Windows.Forms.Panel();
-            this.moreInfoLinkLabel = new System.Windows.Forms.LinkLabel();
             this.dialogText = new System.Windows.Forms.Label();
             this.warningIcon = new System.Windows.Forms.PictureBox();
             this.buttonOK = new System.Windows.Forms.Button();
@@ -43,7 +42,7 @@
             // buttonCancel
             // 
             this.buttonCancel.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.buttonCancel.Location = new System.Drawing.Point(322, 157);
+            this.buttonCancel.Location = new System.Drawing.Point(322, 121);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(67, 24);
             this.buttonCancel.TabIndex = 6;
@@ -54,37 +53,23 @@
             // panel2
             // 
             this.panel2.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.panel2.Controls.Add(this.moreInfoLinkLabel);
             this.panel2.Controls.Add(this.dialogText);
             this.panel2.Controls.Add(this.warningIcon);
             this.panel2.Location = new System.Drawing.Point(0, 0);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(405, 147);
+            this.panel2.Size = new System.Drawing.Size(405, 113);
             this.panel2.TabIndex = 6;
-            // 
-            // moreInfoLinkLabel
-            // 
-            this.moreInfoLinkLabel.AutoSize = true;
-            this.moreInfoLinkLabel.LinkArea = new System.Windows.Forms.LinkArea(6, 4);
-            this.moreInfoLinkLabel.Location = new System.Drawing.Point(54, 65);
-            this.moreInfoLinkLabel.Name = "moreInfoLinkLabel";
-            this.moreInfoLinkLabel.Size = new System.Drawing.Size(162, 17);
-            this.moreInfoLinkLabel.TabIndex = 3;
-            this.moreInfoLinkLabel.TabStop = true;
-            this.moreInfoLinkLabel.Text = "Click here for more information.";
-            this.moreInfoLinkLabel.UseCompatibleTextRendering = true;
-            this.moreInfoLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.MoreInfoLinkLabel_LinkClicked);
             // 
             // dialogText
             // 
             this.dialogText.ImeMode = System.Windows.Forms.ImeMode.NoControl;
             this.dialogText.Location = new System.Drawing.Point(54, 13);
             this.dialogText.Name = "dialogText";
-            this.dialogText.Size = new System.Drawing.Size(306, 101);
+            this.dialogText.Size = new System.Drawing.Size(306, 96);
             this.dialogText.TabIndex = 0;
             this.dialogText.Text = "The selected firmware file was compiled without USB serial support.  The MULTI-Mo" +
-    "dule bootloader should be updated before writing this firmware.\r\n\r\n\r\n\r\nClick OK " +
-    "to write the firmware.";
+    "dule bootloader should be updated before writing this firmware.\r\n\r\nClick OK to w" +
+    "rite the firmware.";
             // 
             // warningIcon
             // 
@@ -99,7 +84,7 @@
             // buttonOK
             // 
             this.buttonOK.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.buttonOK.Location = new System.Drawing.Point(249, 157);
+            this.buttonOK.Location = new System.Drawing.Point(249, 121);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(67, 24);
             this.buttonOK.TabIndex = 5;
@@ -110,9 +95,9 @@
             // disableUsbWarning
             // 
             this.disableUsbWarning.AutoSize = true;
-            this.disableUsbWarning.Location = new System.Drawing.Point(57, 160);
+            this.disableUsbWarning.Location = new System.Drawing.Point(13, 121);
             this.disableUsbWarning.Name = "disableUsbWarning";
-            this.disableUsbWarning.Size = new System.Drawing.Size(179, 17);
+            this.disableUsbWarning.Size = new System.Drawing.Size(196, 19);
             this.disableUsbWarning.TabIndex = 4;
             this.disableUsbWarning.Text = "Do not show this message again";
             this.disableUsbWarning.UseVisualStyleBackColor = true;
@@ -120,12 +105,13 @@
             // UsbSupportWarningDialog
             // 
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.ClientSize = new System.Drawing.Size(404, 187);
+            this.ClientSize = new System.Drawing.Size(404, 152);
             this.ControlBox = false;
             this.Controls.Add(this.disableUsbWarning);
             this.Controls.Add(this.buttonOK);
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.panel2);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
             this.MinimizeBox = false;
@@ -134,7 +120,6 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "USB Support Warning";
             this.panel2.ResumeLayout(false);
-            this.panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.warningIcon)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -149,6 +134,5 @@
         private System.Windows.Forms.PictureBox warningIcon;
         private System.Windows.Forms.Button buttonOK;
         private System.Windows.Forms.CheckBox disableUsbWarning;
-        private System.Windows.Forms.LinkLabel moreInfoLinkLabel;
     }
 }

--- a/src/flash-multi/Dialogs/UsbSupportWarningDialog.Designer.cs
+++ b/src/flash-multi/Dialogs/UsbSupportWarningDialog.Designer.cs
@@ -46,8 +46,7 @@
             this.buttonCancel.Location = new System.Drawing.Point(322, 157);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(67, 24);
-            this.buttonCancel.TabIndex = 5;
-            this.buttonCancel.TabStop = false;
+            this.buttonCancel.TabIndex = 6;
             this.buttonCancel.Text = "Cancel";
             this.buttonCancel.UseVisualStyleBackColor = true;
             this.buttonCancel.Click += new System.EventHandler(this.ButtonCancel_Click);
@@ -103,8 +102,7 @@
             this.buttonOK.Location = new System.Drawing.Point(249, 157);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(67, 24);
-            this.buttonOK.TabIndex = 7;
-            this.buttonOK.TabStop = false;
+            this.buttonOK.TabIndex = 5;
             this.buttonOK.Text = "OK";
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.ButtonOK_Click);
@@ -115,14 +113,13 @@
             this.disableUsbWarning.Location = new System.Drawing.Point(57, 160);
             this.disableUsbWarning.Name = "disableUsbWarning";
             this.disableUsbWarning.Size = new System.Drawing.Size(179, 17);
-            this.disableUsbWarning.TabIndex = 3;
+            this.disableUsbWarning.TabIndex = 4;
             this.disableUsbWarning.Text = "Do not show this message again";
             this.disableUsbWarning.UseVisualStyleBackColor = true;
             // 
             // UsbSupportWarningDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.ClientSize = new System.Drawing.Size(404, 187);
             this.ControlBox = false;
             this.Controls.Add(this.disableUsbWarning);

--- a/src/flash-multi/FileUtils.cs
+++ b/src/flash-multi/FileUtils.cs
@@ -568,7 +568,7 @@ namespace Flash_Multi
             /// <summary>
             /// Gets or sets the module MCU flash size in KB.
             /// </summary>
-            public int ModuleMcuFlashSizeKb{ get; set; }
+            public int ModuleMcuFlashSizeKb { get; set; }
 
             /// <summary>
             /// Gets or sets the channel order the firmware was compiled for.

--- a/src/flash-multi/FlashMulti.Designer.cs
+++ b/src/flash-multi/FlashMulti.Designer.cs
@@ -68,7 +68,6 @@ namespace Flash_Multi
             this.buttonSaveBackup = new System.Windows.Forms.Button();
             this.buttonRead = new System.Windows.Forms.Button();
             this.buttonSerialMonitor = new System.Windows.Forms.Button();
-            this.linkLabel2 = new System.Windows.Forms.LinkLabel();
             this.buttonErase = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.menuStrip2 = new System.Windows.Forms.MenuStrip();
@@ -250,14 +249,6 @@ namespace Flash_Multi
             this.buttonSerialMonitor.UseVisualStyleBackColor = true;
             this.buttonSerialMonitor.Click += new System.EventHandler(this.ButtonSerialMonitor_Click);
             // 
-            // linkLabel2
-            // 
-            resources.ApplyResources(this.linkLabel2, "linkLabel2");
-            this.linkLabel2.Name = "linkLabel2";
-            this.linkLabel2.TabStop = true;
-            this.linkLabel2.UseCompatibleTextRendering = true;
-            this.linkLabel2.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.ReleasesLink_LinkClicked);
-            // 
             // buttonErase
             // 
             resources.ApplyResources(this.buttonErase, "buttonErase");
@@ -436,11 +427,10 @@ namespace Flash_Multi
             // 
             // FlashMulti
             // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.buttonErase);
             this.Controls.Add(this.splitContainer1);
-            this.Controls.Add(this.linkLabel2);
             this.Controls.Add(this.buttonSaveBackup);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.buttonSerialMonitor);
@@ -480,7 +470,6 @@ namespace Flash_Multi
         private System.Windows.Forms.ProgressBar progressBar1;
         private System.Windows.Forms.TextBox textActivity;
         private System.Windows.Forms.LinkLabel linkLabel1;
-        private System.Windows.Forms.LinkLabel linkLabel2;
         private System.Windows.Forms.Button buttonRefresh;
         private System.Windows.Forms.Button buttonSerialMonitor;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;

--- a/src/flash-multi/FlashMulti.cs
+++ b/src/flash-multi/FlashMulti.cs
@@ -1176,8 +1176,9 @@ namespace Flash_Multi
                     if (fileDetails != null)
                     {
                         this.AppendLog($"Multi Firmware Version:   {fileDetails.Version} ({fileDetails.ModuleType})\r\n");
+                        this.AppendLog($"Firmware Target:          {fileDetails.ModuleSubType} ({fileDetails.ModuleMcuFlashSizeKb}KB)\r\n");
                         this.AppendLog($"Expected Channel Order:   {fileDetails.ChannelOrder}\r\n");
-                        this.AppendLog($"Multi Telemetry Type:     {fileDetails.MultiTelemetryType}\r\n");
+                        this.AppendLog($"Telemetry Type:           {fileDetails.MultiTelemetryType}\r\n");
                         this.AppendLog($"Invert Telemetry Enabled: {fileDetails.InvertTelemetry}\r\n");
                         this.AppendLog($"Flash from Radio Enabled: {fileDetails.CheckForBootloader}\r\n");
                         this.AppendLog($"Bootloader Enabled:       {fileDetails.BootloaderSupport}\r\n");
@@ -1603,8 +1604,9 @@ namespace Flash_Multi
                         {
                             this.AppendLog($"Firmware File Name:       {this.textFileName.Text.Substring(this.textFileName.Text.LastIndexOf("\\") + 1)}\r\n");
                             this.AppendLog($"Multi Firmware Version:   {fileDetails.Version} ({fileDetails.ModuleType})\r\n");
+                            this.AppendLog($"Firmware Target:          {fileDetails.ModuleSubType} ({fileDetails.ModuleMcuFlashSizeKb}KB)\r\n");
                             this.AppendLog($"Expected Channel Order:   {fileDetails.ChannelOrder}\r\n");
-                            this.AppendLog($"Multi Telemetry Type:     {fileDetails.MultiTelemetryType}\r\n");
+                            this.AppendLog($"Telemetry Type:           {fileDetails.MultiTelemetryType}\r\n");
                             this.AppendLog($"Invert Telemetry Enabled: {fileDetails.InvertTelemetry}\r\n");
                             this.AppendLog($"Flash from Radio Enabled: {fileDetails.CheckForBootloader}\r\n");
                             this.AppendLog($"Bootloader Enabled:       {fileDetails.BootloaderSupport}\r\n");

--- a/src/flash-multi/FlashMulti.cs
+++ b/src/flash-multi/FlashMulti.cs
@@ -152,9 +152,17 @@ namespace Flash_Multi
             // Set 'Enable Flash Verification' from the settings
             this.disableCompatibilityCheckToolStripMenuItem.Checked = Settings.Default.DisableFlashVerification;
 
+            /*
             // Set the 'Bootloader / USB Port' mode from the settings
             this.comPortUsbModeToolStripMenuItem.Checked = Settings.Default.ErrorIfNoUSB;
             this.stickyDfuUsbModeToolStripMenuItem.Checked = !Settings.Default.ErrorIfNoUSB;
+            */
+
+            // Force sticky-dfu bootloader
+            this.stickyDfuUsbModeToolStripMenuItem.Checked = true;
+            this.comPortUsbModeToolStripMenuItem.Checked = false;
+            Settings.Default.ErrorIfNoUSB = false;
+            Settings.Default.Save();
 
             // Hide the verbose output panel and set the height of the other panel
             int initialHeight = 215;

--- a/src/flash-multi/FlashMulti.cs
+++ b/src/flash-multi/FlashMulti.cs
@@ -124,7 +124,7 @@ namespace Flash_Multi
             this.Text = string.Format("Flash Multi v{0}", Application.ProductVersion);
 
             // Set focus away from the textbox
-            this.ActiveControl = this.linkLabel2;
+            this.ActiveControl = this.label2;
 
             // Populate the list of serial ports
             this.PopulateComPorts();

--- a/src/flash-multi/FlashMulti.resx
+++ b/src/flash-multi/FlashMulti.resx
@@ -135,27 +135,6 @@
   <data name="tableLayoutPanel1.ColumnCount" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="textActivity.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="textActivity.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Consolas, 8.25pt</value>
-  </data>
-  <data name="textActivity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="textActivity.Multiline" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="textActivity.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
-    <value>Both</value>
-  </data>
-  <data name="textActivity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>529, 104</value>
-  </data>
-  <data name="textActivity.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
   <data name="&gt;&gt;textActivity.Name" xml:space="preserve">
     <value>textActivity</value>
   </data>
@@ -167,27 +146,6 @@
   </data>
   <data name="&gt;&gt;textActivity.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="showVerboseOutput.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="showVerboseOutput.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="showVerboseOutput.CheckAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="showVerboseOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>402, 143</value>
-  </data>
-  <data name="showVerboseOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>130, 17</value>
-  </data>
-  <data name="showVerboseOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="showVerboseOutput.Text" xml:space="preserve">
-    <value>Show Verbose Output</value>
   </data>
   <data name="&gt;&gt;showVerboseOutput.Name" xml:space="preserve">
     <value>showVerboseOutput</value>
@@ -201,18 +159,6 @@
   <data name="&gt;&gt;showVerboseOutput.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="progressBar1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left, Right</value>
-  </data>
-  <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 114</value>
-  </data>
-  <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>529, 23</value>
-  </data>
-  <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
   <data name="&gt;&gt;progressBar1.Name" xml:space="preserve">
     <value>progressBar1</value>
   </data>
@@ -224,24 +170,6 @@
   </data>
   <data name="&gt;&gt;progressBar1.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="linkLabel1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="linkLabel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 143</value>
-  </data>
-  <data name="linkLabel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 0</value>
-  </data>
-  <data name="linkLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 13</value>
-  </data>
-  <data name="linkLabel1.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="linkLabel1.Text" xml:space="preserve">
-    <value>https://github.com/benlye/flash-multi</value>
   </data>
   <data name="&gt;&gt;linkLabel1.Name" xml:space="preserve">
     <value>linkLabel1</value>
@@ -378,8 +306,137 @@
   <data name="&gt;&gt;splitContainer1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="textActivity.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="textActivity.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Consolas, 8.25pt</value>
+  </data>
+  <data name="textActivity.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="textActivity.Multiline" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="textActivity.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>Both</value>
+  </data>
+  <data name="textActivity.Size" type="System.Drawing.Size, System.Drawing">
+    <value>529, 104</value>
+  </data>
+  <data name="textActivity.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;textActivity.Name" xml:space="preserve">
+    <value>textActivity</value>
+  </data>
+  <data name="&gt;&gt;textActivity.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;textActivity.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;textActivity.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="showVerboseOutput.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="showVerboseOutput.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showVerboseOutput.CheckAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="showVerboseOutput.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 8.25pt</value>
+  </data>
+  <data name="showVerboseOutput.Location" type="System.Drawing.Point, System.Drawing">
+    <value>392, 143</value>
+  </data>
+  <data name="showVerboseOutput.Size" type="System.Drawing.Size, System.Drawing">
+    <value>140, 17</value>
+  </data>
+  <data name="showVerboseOutput.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="showVerboseOutput.Text" xml:space="preserve">
+    <value>Show Verbose Output</value>
+  </data>
+  <data name="&gt;&gt;showVerboseOutput.Name" xml:space="preserve">
+    <value>showVerboseOutput</value>
+  </data>
+  <data name="&gt;&gt;showVerboseOutput.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showVerboseOutput.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;showVerboseOutput.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="progressBar1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left, Right</value>
+  </data>
+  <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 114</value>
+  </data>
+  <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>529, 23</value>
+  </data>
+  <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Name" xml:space="preserve">
+    <value>progressBar1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;progressBar1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="linkLabel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="linkLabel1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
+  </data>
+  <data name="linkLabel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 143</value>
+  </data>
+  <data name="linkLabel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 0</value>
+  </data>
+  <data name="linkLabel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>212, 15</value>
+  </data>
+  <data name="linkLabel1.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="linkLabel1.Text" xml:space="preserve">
+    <value>https://github.com/benlye/flash-multi</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Name" xml:space="preserve">
+    <value>linkLabel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Parent" xml:space="preserve">
+    <value>tableLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="buttonUpload.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top</value>
+  </data>
+  <data name="buttonUpload.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="buttonUpload.Location" type="System.Drawing.Point, System.Drawing">
     <value>423, 124</value>
@@ -406,13 +463,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;buttonUpload.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>5</value>
   </data>
   <data name="comPortSelector.Location" type="System.Drawing.Point, System.Drawing">
-    <value>91, 48</value>
+    <value>95, 48</value>
   </data>
   <data name="comPortSelector.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 21</value>
+    <value>90, 23</value>
   </data>
   <data name="comPortSelector.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -433,10 +490,10 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="textFileName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>91, 20</value>
+    <value>95, 20</value>
   </data>
   <data name="textFileName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>354, 20</value>
+    <value>350, 23</value>
   </data>
   <data name="textFileName.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -460,7 +517,7 @@
     <value>14, 24</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
+    <value>80, 15</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -487,7 +544,7 @@
     <value>14, 52</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 13</value>
+    <value>63, 15</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -510,11 +567,14 @@
   <data name="buttonBrowse.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Right</value>
   </data>
+  <data name="buttonBrowse.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="buttonBrowse.Location" type="System.Drawing.Point, System.Drawing">
     <value>451, 19</value>
   </data>
   <data name="buttonBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 22</value>
+    <value>75, 24</value>
   </data>
   <data name="buttonBrowse.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -537,18 +597,6 @@
   <data name="groupBox1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="buttonRefresh.Location" type="System.Drawing.Point, System.Drawing">
-    <value>187, 47</value>
-  </data>
-  <data name="buttonRefresh.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
-  </data>
-  <data name="buttonRefresh.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="buttonRefresh.Text" xml:space="preserve">
-    <value>Refresh Ports</value>
-  </data>
   <data name="&gt;&gt;buttonRefresh.Name" xml:space="preserve">
     <value>buttonRefresh</value>
   </data>
@@ -560,6 +608,9 @@
   </data>
   <data name="&gt;&gt;buttonRefresh.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="groupBox1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
     <value>11, 28</value>
@@ -583,10 +634,37 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>3</value>
+  </data>
+  <data name="buttonRefresh.Location" type="System.Drawing.Point, System.Drawing">
+    <value>192, 47</value>
+  </data>
+  <data name="buttonRefresh.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 24</value>
+  </data>
+  <data name="buttonRefresh.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="buttonRefresh.Text" xml:space="preserve">
+    <value>Refresh Ports</value>
+  </data>
+  <data name="&gt;&gt;buttonRefresh.Name" xml:space="preserve">
+    <value>buttonRefresh</value>
+  </data>
+  <data name="&gt;&gt;buttonRefresh.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;buttonRefresh.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;buttonRefresh.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="buttonSaveBackup.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top</value>
+  </data>
+  <data name="buttonSaveBackup.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="buttonSaveBackup.Location" type="System.Drawing.Point, System.Drawing">
     <value>231, 124</value>
@@ -613,10 +691,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;buttonSaveBackup.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>2</value>
   </data>
   <data name="buttonRead.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top</value>
+  </data>
+  <data name="buttonRead.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="buttonRead.Location" type="System.Drawing.Point, System.Drawing">
     <value>135, 124</value>
@@ -643,10 +724,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;buttonRead.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>6</value>
   </data>
   <data name="buttonSerialMonitor.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top</value>
+  </data>
+  <data name="buttonSerialMonitor.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="buttonSerialMonitor.Location" type="System.Drawing.Point, System.Drawing">
     <value>39, 124</value>
@@ -670,40 +754,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;buttonSerialMonitor.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="linkLabel2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="linkLabel2.LinkArea" type="System.Windows.Forms.LinkArea, System.Windows.Forms">
-    <value>77, 4</value>
-  </data>
-  <data name="linkLabel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>39, 375</value>
-  </data>
-  <data name="linkLabel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>417, 17</value>
-  </data>
-  <data name="linkLabel2.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="linkLabel2.Text" xml:space="preserve">
-    <value>Read, write, and erase MULTI-Module firmware.  Get the latest firmware files here.</value>
-  </data>
-  <data name="&gt;&gt;linkLabel2.Name" xml:space="preserve">
-    <value>linkLabel2</value>
-  </data>
-  <data name="&gt;&gt;linkLabel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;linkLabel2.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;linkLabel2.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="buttonErase.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top</value>
+  </data>
+  <data name="buttonErase.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Segoe UI, 9pt</value>
   </data>
   <data name="buttonErase.Location" type="System.Drawing.Point, System.Drawing">
     <value>327, 124</value>
@@ -738,17 +795,59 @@
   <metadata name="menuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>229, 17</value>
   </metadata>
-  <data name="exitToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 22</value>
+  <data name="menuStrip2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
   </data>
-  <data name="exitToolStripMenuItem.Text" xml:space="preserve">
-    <value>E&amp;xit</value>
+  <data name="menuStrip2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>554, 24</value>
+  </data>
+  <data name="menuStrip2.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="menuStrip2.Text" xml:space="preserve">
+    <value>menuStrip2</value>
+  </data>
+  <data name="&gt;&gt;menuStrip2.Name" xml:space="preserve">
+    <value>menuStrip2</value>
+  </data>
+  <data name="&gt;&gt;menuStrip2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menuStrip2.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;menuStrip2.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
   <data name="fileToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>37, 20</value>
   </data>
   <data name="fileToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;File</value>
+  </data>
+  <data name="exitToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 22</value>
+  </data>
+  <data name="exitToolStripMenuItem.Text" xml:space="preserve">
+    <value>E&amp;xit</value>
+  </data>
+  <data name="advancedToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 20</value>
+  </data>
+  <data name="advancedToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Advanced</value>
+  </data>
+  <data name="settingsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 22</value>
+  </data>
+  <data name="settingsToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Settings</value>
+  </data>
+  <data name="baudRateToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>207, 22</value>
+  </data>
+  <data name="baudRateToolStripMenuItem.Text" xml:space="preserve">
+    <value>Serial &amp;Baud Rate</value>
   </data>
   <data name="toolStripMenuItemBaudRate57600.Size" type="System.Drawing.Size, System.Drawing">
     <value>110, 22</value>
@@ -768,11 +867,14 @@
   <data name="toolStripMenuItemBaudRate500000.Text" xml:space="preserve">
     <value>500000</value>
   </data>
-  <data name="baudRateToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="bootloaderTypeToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>207, 22</value>
   </data>
-  <data name="baudRateToolStripMenuItem.Text" xml:space="preserve">
-    <value>Serial &amp;Baud Rate</value>
+  <data name="bootloaderTypeToolStripMenuItem.Text" xml:space="preserve">
+    <value>USB Port Mode</value>
+  </data>
+  <data name="bootloaderTypeToolStripMenuItem.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="stickyDfuUsbModeToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>199, 22</value>
@@ -785,15 +887,6 @@
   </data>
   <data name="comPortUsbModeToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;COM Port (Legacy)</value>
-  </data>
-  <data name="bootloaderTypeToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>207, 22</value>
-  </data>
-  <data name="bootloaderTypeToolStripMenuItem.Text" xml:space="preserve">
-    <value>USB Port Mode</value>
-  </data>
-  <data name="bootloaderTypeToolStripMenuItem.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
   </data>
   <data name="disableCompatibilityCheckToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>207, 22</value>
@@ -813,11 +906,11 @@
   <data name="runAfterUploadToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Run Firmware After Write</value>
   </data>
-  <data name="settingsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="actionsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>180, 22</value>
   </data>
-  <data name="settingsToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Settings</value>
+  <data name="actionsToolStripMenuItem.Text" xml:space="preserve">
+    <value>A&amp;ctions</value>
   </data>
   <data name="installUSBDriversToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>219, 22</value>
@@ -846,17 +939,11 @@
   <data name="runFirmwareToolStripMenuItem.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="actionsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
+  <data name="helpToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 20</value>
   </data>
-  <data name="actionsToolStripMenuItem.Text" xml:space="preserve">
-    <value>A&amp;ctions</value>
-  </data>
-  <data name="advancedToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 20</value>
-  </data>
-  <data name="advancedToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Advanced</value>
+  <data name="helpToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Help</value>
   </data>
   <data name="checkForUpdateToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>226, 22</value>
@@ -876,42 +963,9 @@
   <data name="downloadFirmwareToolStripMenuItem.Text" xml:space="preserve">
     <value>Get MULTI-Module Firmware</value>
   </data>
-  <data name="helpToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 20</value>
-  </data>
-  <data name="helpToolStripMenuItem.Text" xml:space="preserve">
-    <value>&amp;Help</value>
-  </data>
-  <data name="menuStrip2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="menuStrip2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>554, 24</value>
-  </data>
-  <data name="menuStrip2.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="menuStrip2.Text" xml:space="preserve">
-    <value>menuStrip2</value>
-  </data>
-  <data name="&gt;&gt;menuStrip2.Name" xml:space="preserve">
-    <value>menuStrip2</value>
-  </data>
-  <data name="&gt;&gt;menuStrip2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;menuStrip2.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;menuStrip2.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>554, 401</value>
   </data>

--- a/src/flash-multi/FlashMulti.resx
+++ b/src/flash-multi/FlashMulti.resx
@@ -792,6 +792,9 @@
   <data name="bootloaderTypeToolStripMenuItem.Text" xml:space="preserve">
     <value>USB Port Mode</value>
   </data>
+  <data name="bootloaderTypeToolStripMenuItem.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="disableCompatibilityCheckToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>207, 22</value>
   </data>

--- a/src/flash-multi/Properties/AssemblyInfo.cs
+++ b/src/flash-multi/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.1")]
-[assembly: AssemblyFileVersion("0.5.1")]
+[assembly: AssemblyVersion("0.5.2")]
+[assembly: AssemblyFileVersion("0.5.2")]

--- a/src/flash-multi/Properties/AssemblyInfo.cs
+++ b/src/flash-multi/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.2")]
-[assembly: AssemblyFileVersion("0.5.2")]
+[assembly: AssemblyVersion("0.6.0")]
+[assembly: AssemblyFileVersion("0.6.0")]

--- a/src/flash-multi/Properties/Settings.Designer.cs
+++ b/src/flash-multi/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Flash_Multi.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -85,7 +85,7 @@ namespace Flash_Multi.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool RunAfterUpload {
             get {
                 return ((bool)(this["RunAfterUpload"]));
@@ -109,7 +109,7 @@ namespace Flash_Multi.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool ErrorIfNoUSB {
             get {
                 return ((bool)(this["ErrorIfNoUSB"]));

--- a/src/flash-multi/Properties/Settings.settings
+++ b/src/flash-multi/Properties/Settings.settings
@@ -18,13 +18,13 @@
       <Value Profile="(Default)">en-US</Value>
     </Setting>
     <Setting Name="RunAfterUpload" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="EnableDeviceDetection" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="ErrorIfNoUSB" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="WarnIfNoUSB" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>

--- a/src/flash-multi/app.config
+++ b/src/flash-multi/app.config
@@ -23,13 +23,13 @@
                 <value>en-US</value>
             </setting>
             <setting name="RunAfterUpload" serializeAs="String">
-                <value>True</value>
+                <value>False</value>
             </setting>
             <setting name="EnableDeviceDetection" serializeAs="String">
                 <value>True</value>
             </setting>
             <setting name="ErrorIfNoUSB" serializeAs="String">
-                <value>True</value>
+                <value>False</value>
             </setting>
             <setting name="WarnIfNoUSB" serializeAs="String">
                 <value>True</value>


### PR DESCRIPTION
* Segoe UI gives a better experience on systems that do not use Latin characters (i.e. Chinese) due to better fallback fonts
* Disable windows and dialogs auto-scaling when the font changes to keep the UI consistent (addresses #34)
* Remove the bootloader choice and always use the sticky DFU bootloader when updating the bootloader via DFU
* Update signature parser for latest signature version (differentiate STM32 module sub-types)