### PR TITLE
add nix derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,6 @@ ASALocalRun/
 
 # Coverity
 cov-int/
+
+# nix stuff
+**/result

--- a/doc/Linux.md
+++ b/doc/Linux.md
@@ -135,3 +135,20 @@ Starting execution at address 0x08002000... done.
 Firmware flashed successfully.
 
 ```
+
+# Using `nix`
+
+In case you happen to have [`nix`](https://nixos.org/explore.html) installed,
+you can simply use the `default.nix` file in the linux folder to build a
+compatible derivation of both `flash-multi` and `multi-bootreloader`. To
+install it in your users environment, simply run `nix-env -f . -i`.
+
+Beware: This does not alter udev rules, so you likely will run into permission
+problems with the DFU device and/or the serial device. Possible solution in
+descending level of recommendability:
+
++ install appropiate udev rules in your system
++ run the script in question as `root` user
++ run `while true; do sudo chown $USER /dev/bus/usb/*; done` while using the
+  script. Afterwards run `sudo udevadm control --reload-rules && udevadm trigger` to
+  reaply all udev rules in question.

--- a/linux/default.nix
+++ b/linux/default.nix
@@ -1,0 +1,21 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "flash-multi";
+
+  src = ./.;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ libusb ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,${name}}
+    mv * $out/${name}/
+    ln -s $out/${name}/flash-multi $out/bin/
+    ln -s $out/${name}/multi-bootreloader $out/bin/
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
This allows nix users to easily run the scripts on systems with nix

This is only a quick hack. Ideally, we would make this more idiomatic: All supplied binaries go in a bin folder, this folder is added to the `$PATH` in the beginning of both script. A env var could be used to allow both nix and the user to prefer system binaries instead of those shipped with `flash-multi`.

Any feedback welcome :)